### PR TITLE
Use ActiveSupport like option extraction for less strict method signatures.

### DIFF
--- a/lib/caracal/core/images.rb
+++ b/lib/caracal/core/images.rb
@@ -16,8 +16,9 @@ module Caracal
           # Public Methods
           #-------------------------------------------------------------
           
-          def img(url = nil, options={}, &block)
-            options.merge!({ url: url }) if url
+          def img(*args, &block)
+            options = args.last.is_a?(Hash) ? args.pop : {}
+            options.merge!({ url: args[0] }) if args[0]
             
             model = Caracal::Core::Models::ImageModel.new(options, &block)
             if model.valid?

--- a/lib/caracal/core/models/list_model.rb
+++ b/lib/caracal/core/models/list_model.rb
@@ -91,8 +91,9 @@ module Caracal
         #=============== SUB-METHODS ===========================
         
         # .li
-        def li(content = nil, options = {}, &block)
-          options.merge!({ content: content }) if content
+        def li(*args, &block)
+          options = args.last.is_a?(Hash) ? args.pop : {}
+          options.merge!({ content: args[0] }) if args[0]
           options.merge!({ type:    list_type  })
           options.merge!({ level:   list_level })
           

--- a/lib/caracal/core/models/paragraph_model.rb
+++ b/lib/caracal/core/models/paragraph_model.rb
@@ -93,9 +93,10 @@ module Caracal
         #=============== SUB-METHODS ===========================
         
         # .link
-        def link(content = nil, href = nil, options = {}, &block)
-          options.merge!({ content: content }) if content
-          options.merge!({ href:    href    }) if href
+        def link(*args, &block)
+          options = args.last.is_a?(Hash) ? args.pop : {}
+          options.merge!({ content: args[0] }) if args[0]
+          options.merge!({ href:    args[1]    }) if args[1]
           
           model = Caracal::Core::Models::LinkModel.new(options, &block)
           if model.valid?
@@ -106,8 +107,9 @@ module Caracal
         end
         
         # .text
-        def text(content = nil, options = {}, &block)
-          options.merge!({ content: content }) if content
+        def text(*args, &block)
+          options = args.last.is_a?(Hash) ? args.pop : {}
+          options.merge!({ content: args[0] }) if args[0]
           
           model = Caracal::Core::Models::TextModel.new(options, &block)
           if model.valid?

--- a/lib/caracal/core/text.rb
+++ b/lib/caracal/core/text.rb
@@ -18,8 +18,9 @@ module Caracal
           
           #============== PARAGRAPHS ==========================
           
-          def p(text = nil, options = {}, &block)
-            options.merge!({ content: text }) if text
+          def p(*args, &block)
+            options = args.last.is_a?(Hash) ? args.pop : {}
+            options.merge!({ content: args[0] }) if args[0]
             
             model = Caracal::Core::Models::ParagraphModel.new(options, &block)
             if model.valid?
@@ -37,9 +38,10 @@ module Caracal
           # model with an explicitly set style class.
           #
           [:h1, :h2, :h3, :h4, :h5, :h6].each do |cmd|
-            define_method "#{ cmd }" do |text = nil, options = {}, &block|
+            define_method "#{ cmd }" do |*args, &block|
+              options = args.last.is_a?(Hash) ? args.pop : {}
               options.merge!({ style: style_id_for_header(cmd) })
-              p(text, options, &block)
+              p(*args, options, &block)
             end
           end
           


### PR DESCRIPTION
So, this is pretty much how ActiveSupport does it, though this doesn't use the monkey patches on Array. I think this should fix your problems.
