### PR TITLE
Support for images for word 2007

### DIFF
--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -123,11 +123,11 @@ module Caracal
                     xml.send 'pic:pic' do
                       xml.send 'pic:nvPicPr' do
                         xml.send 'pic:cNvPr', { id: rel_id, name: rel_name }
-                        xml.send 'pic:cNvPicPr', { preferRelativeSize: 0 }
+                        xml.send 'pic:cNvPicPr'
                       end
                       xml.send 'pic:blipFill' do
                         xml.send 'a:blip', { 'r:embed' => rel.formatted_id }
-                        xml.send 'a:srcRect', { t: 0, b: 0, r: 0, l: 0 }
+                        xml.send 'a:srcRect'
                         xml.send 'a:stretch' do
                           xml.send 'a:fillRect'
                         end


### PR DESCRIPTION
There was a bug with displaying images in word 2007... Removing this
lines make caracal compatible with word 2007