### PR TITLE
added vertical_alignment option for table cell

### DIFF
--- a/lib/caracal/core/models/table_cell_model.rb
+++ b/lib/caracal/core/models/table_cell_model.rb
@@ -16,19 +16,22 @@ module Caracal
         #-------------------------------------------------------------
         
         # constants
-        const_set(:DEFAULT_CELL_BACKGROUND,   'ffffff')
-        const_set(:DEFAULT_CELL_MARGINS,      Caracal::Core::Models::MarginModel.new({ top: 100, bottom: 100, left: 100, right: 100 }))
-        
+        const_set(:DEFAULT_CELL_BACKGROUND,       'ffffff')
+        const_set(:DEFAULT_CELL_MARGINS,          Caracal::Core::Models::MarginModel.new({ top: 100, bottom: 100, left: 100, right: 100 }))
+        const_set(:DEFAULT_CELL_VERTICAL_ALIGN,   :top)
+
         # accessors
         attr_reader :cell_background 
         attr_reader :cell_width
         attr_reader :cell_margins
-        
+        attr_reader :cell_vertical_align
+
         # initialization
         def initialize(options={}, &block)
-          @cell_background = DEFAULT_CELL_BACKGROUND
-          @cell_margins    = DEFAULT_CELL_MARGINS
-          
+          @cell_background      = DEFAULT_CELL_BACKGROUND
+          @cell_margins         = DEFAULT_CELL_MARGINS
+          @cell_vertical_align  = DEFAULT_CELL_VERTICAL_ALIGN
+
           if content = options.delete(:content)
             p content, options.dup
           end
@@ -134,8 +137,15 @@ module Caracal
             instance_variable_set("@cell_#{ m }", value.to_s)
           end
         end
-        
-        
+
+        #symbols
+        [:vertical_align].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set("@cell_#{ m }", value.to_s.to_sym)
+          end
+        end
+
+
         #=============== VALIDATION ===========================
         
         def valid?
@@ -149,7 +159,7 @@ module Caracal
         private
         
         def option_keys
-          [:background, :margins, :width]
+          [:background, :margins, :width, :vertical_align]
         end
         
       end

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -300,6 +300,7 @@ module Caracal
                 xml.send 'w:tc' do
                   xml.send 'tcPr' do
                     xml.send 'w:shd', { 'w:fill' => tc.cell_background }
+                    xml.send 'w:vAlign', { 'w:val' => tc.cell_vertical_align }
                     xml.send 'w:tcMar' do
                       %w(top left bottom right).each do |d|
                         xml.send "w:#{ d }", { 'w:w' => tc.send("cell_margin_#{ d }").to_f, 'w:type' => 'dxa' }

--- a/spec/lib/caracal/core/models/table_cell_model_spec.rb
+++ b/spec/lib/caracal/core/models/table_cell_model_spec.rb
@@ -23,6 +23,7 @@ describe Caracal::Core::Models::TableCellModel do
     # constants
     describe 'constants' do
       it { expect(described_class::DEFAULT_CELL_BACKGROUND).to            eq 'ffffff' }
+      it { expect(described_class::DEFAULT_CELL_VERTICAL_ALIGN).to        eq :top }
       it { expect(described_class::DEFAULT_CELL_MARGINS).to               be_a(Caracal::Core::Models::MarginModel) }
       it { expect(described_class::DEFAULT_CELL_MARGINS.margin_top).to    eq 100 }
       it { expect(described_class::DEFAULT_CELL_MARGINS.margin_bottom).to eq 100 }
@@ -35,6 +36,7 @@ describe Caracal::Core::Models::TableCellModel do
       it { expect(subject.cell_background).to     eq 'cccccc' }
       it { expect(subject.cell_margins).to        be_a(Caracal::Core::Models::MarginModel) }
       it { expect(subject.cell_width).to          eq 2000 }
+      it { expect(subject.cell_vertical_align).to          eq :top }
     end
     
   end
@@ -94,6 +96,13 @@ describe Caracal::Core::Models::TableCellModel do
       before { subject.width(7500) }
       
       it { expect(subject.cell_width).to eq 7500 }
+    end
+
+    #.vertical_allign
+    describe '.vertical_align' do
+      before { subject.vertical_align(:center) }
+
+      it { expect(subject.cell_vertical_align).to eq :center }
     end
     
     
@@ -211,7 +220,7 @@ describe Caracal::Core::Models::TableCellModel do
     # .option_keys
     describe '.option_keys' do
       let(:actual)     { subject.send(:option_keys).sort }
-      let(:expected)   { [:background, :width, :margins].sort }
+      let(:expected)   { [:background, :width, :vertical_align, :margins].sort }
       
       it { expect(actual).to eq expected }
     end


### PR DESCRIPTION
Hello! I have not found an ability to set vertical alignment property for a particular table cell, however OOXML allows us to do so. I am not sure I did it in the right way, so feel free to let me know your thoughts 

Thanks!