### PR TITLE
Allow text to be placed to the left of the page number

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,12 +301,13 @@ docx.page     # starts a new page.
 
 ### Page Numbers
 
-Page numbers can be added to the footer via the `page_numbers` method.  The method accepts an optional parameter for controlling the alignment of the text.
+Page numbers can be added to the footer via the `page_numbers` method.  The method accepts optional parameters for controlling the label and alignment of the text.
 
 *Page numbers are turned off by default.*
 
 ```ruby
 docx.page_numbers true do
+  label 'Page'     # sets the text that will go to the left of the page number. Defaults to nil.
   align :right     # sets the alignment. accepts :left, :center, and :right.
 end
 ```

--- a/lib/caracal/core/models/page_number_model.rb
+++ b/lib/caracal/core/models/page_number_model.rb
@@ -19,11 +19,13 @@ module Caracal
         const_set(:DEFAULT_PAGE_NUMBER_ALIGN, :center)
         
         # accessors
+        attr_reader :page_number_text
         attr_reader :page_number_align
         attr_reader :page_number_show
         
         # initialization
         def initialize(options={}, &block)
+          @page_number_text = nil
           @page_number_show  = DEFAULT_PAGE_NUMBER_SHOW
           @page_number_align = DEFAULT_PAGE_NUMBER_ALIGN
           
@@ -36,7 +38,11 @@ module Caracal
         #-------------------------------------------------------------
     
         #=============== SETTERS ==============================
-        
+
+        def text(value)
+          @page_number_text = value.to_s
+        end
+
         def align(value)
           @page_number_align = value.to_s.to_sym
         end
@@ -59,7 +65,7 @@ module Caracal
         private
         
         def option_keys
-          [:align, :show]
+          [:text, :align, :show]
         end
         
       end

--- a/lib/caracal/core/models/page_number_model.rb
+++ b/lib/caracal/core/models/page_number_model.rb
@@ -19,13 +19,13 @@ module Caracal
         const_set(:DEFAULT_PAGE_NUMBER_ALIGN, :center)
         
         # accessors
-        attr_reader :page_number_text
+        attr_reader :page_number_label
         attr_reader :page_number_align
         attr_reader :page_number_show
         
         # initialization
         def initialize(options={}, &block)
-          @page_number_text = nil
+          @page_number_label = nil
           @page_number_show  = DEFAULT_PAGE_NUMBER_SHOW
           @page_number_align = DEFAULT_PAGE_NUMBER_ALIGN
           
@@ -39,8 +39,8 @@ module Caracal
     
         #=============== SETTERS ==============================
 
-        def text(value)
-          @page_number_text = value.to_s
+        def label(value)
+          @page_number_label = value.to_s
         end
 
         def align(value)
@@ -65,7 +65,7 @@ module Caracal
         private
         
         def option_keys
-          [:text, :align, :show]
+          [:label, :align, :show]
         end
         
       end

--- a/lib/caracal/core/page_numbers.rb
+++ b/lib/caracal/core/page_numbers.rb
@@ -20,6 +20,7 @@ module Caracal
           const_set(:DEFAULT_PAGE_NUMBER_ALIGN,  :center)
           
           # accessors
+          attr_reader :page_number_text
           attr_reader :page_number_show
           attr_reader :page_number_align
           
@@ -37,6 +38,7 @@ module Caracal
             
             model = Caracal::Core::Models::PageNumberModel.new(options, &block)
             if model.valid?
+              @page_number_text  = model.page_number_text
               @page_number_show  = model.page_number_show
               @page_number_align = model.page_number_align
             else

--- a/lib/caracal/core/page_numbers.rb
+++ b/lib/caracal/core/page_numbers.rb
@@ -20,7 +20,7 @@ module Caracal
           const_set(:DEFAULT_PAGE_NUMBER_ALIGN,  :center)
           
           # accessors
-          attr_reader :page_number_text
+          attr_reader :page_number_label
           attr_reader :page_number_show
           attr_reader :page_number_align
           
@@ -38,7 +38,7 @@ module Caracal
             
             model = Caracal::Core::Models::PageNumberModel.new(options, &block)
             if model.valid?
-              @page_number_text  = model.page_number_text
+              @page_number_label = model.page_number_label
               @page_number_show  = model.page_number_show
               @page_number_align = model.page_number_align
             else

--- a/lib/caracal/renderers/footer_renderer.rb
+++ b/lib/caracal/renderers/footer_renderer.rb
@@ -22,6 +22,17 @@ module Caracal
                 xml.send 'w:contextualSpacing', { 'w:val' => '0' }
                 xml.send 'w:jc', { 'w:val' => "#{ document.page_number_align }" }
               end
+              if document.page_number_text.present?
+                xml.send 'w:r', run_options do
+                  xml.send 'w:rPr' do
+                    xml.send 'w:rStyle', { 'w:val' => 'PageNumber' }
+                  end
+                  xml.send 'w:t', { 'xml:space' => 'preserve' } do
+                    # Ensure there is a space at the end to separate text from page number
+                    xml.text "#{document.page_number_text} "
+                  end
+                end
+              end
               xml.send 'w:fldSimple', { 'w:dirty' => '0', 'w:instr' => 'PAGE', 'w:fldLock' => '0' } do
                 xml.send 'w:r', run_options do
                   xml.send 'w:rPr'

--- a/lib/caracal/renderers/footer_renderer.rb
+++ b/lib/caracal/renderers/footer_renderer.rb
@@ -28,8 +28,8 @@ module Caracal
                     xml.send 'w:rStyle', { 'w:val' => 'PageNumber' }
                   end
                   xml.send 'w:t', { 'xml:space' => 'preserve' } do
-                    # Ensure there is a space at the end to separate text from page number
-                    xml.text "#{document.page_number_text} "
+                    # Ensure there is a space at the end to separate the label from the page number
+                    xml.text "#{document.page_number_label} "
                   end
                 end
               end

--- a/spec/lib/caracal/core/models/page_number_model_spec.rb
+++ b/spec/lib/caracal/core/models/page_number_model_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Caracal::Core::Models::PageNumberModel do
   subject do 
     described_class.new do
-      text 'Page'
+      label 'Page'
       show  true
       align :right
     end
@@ -22,7 +22,7 @@ describe Caracal::Core::Models::PageNumberModel do
     
     # accessors
     describe 'accessors' do
-      it { expect(subject.page_number_text).to eq 'Page' }
+      it { expect(subject.page_number_label).to eq 'Page' }
       it { expect(subject.page_number_align).to eq :right }
       it { expect(subject.page_number_show).to eq true }
     end
@@ -39,10 +39,10 @@ describe Caracal::Core::Models::PageNumberModel do
     #=============== SETTERS ==============================
 
     # .text
-    describe '.text' do
-      before { subject.text('Page') }
+    describe '.label' do
+      before { subject.label('Page') }
 
-      it { expect(subject.page_number_text).to eq 'Page' }
+      it { expect(subject.page_number_label).to eq 'Page' }
     end
 
     # .align
@@ -100,7 +100,7 @@ describe Caracal::Core::Models::PageNumberModel do
     # .option_keys
     describe '.option_keys' do
       let(:actual)   { subject.send(:option_keys).sort }
-      let(:expected) { [:text, :align, :show].sort }
+      let(:expected) { [:label, :align, :show].sort }
       
       it { expect(actual).to eq expected }
     end

--- a/spec/lib/caracal/core/models/page_number_model_spec.rb
+++ b/spec/lib/caracal/core/models/page_number_model_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Caracal::Core::Models::PageNumberModel do
   subject do 
     described_class.new do
+      text 'Page'
       show  true
       align :right
     end
@@ -21,6 +22,7 @@ describe Caracal::Core::Models::PageNumberModel do
     
     # accessors
     describe 'accessors' do
+      it { expect(subject.page_number_text).to eq 'Page' }
       it { expect(subject.page_number_align).to eq :right }
       it { expect(subject.page_number_show).to eq true }
     end
@@ -35,7 +37,14 @@ describe Caracal::Core::Models::PageNumberModel do
   describe 'public method tests' do
     
     #=============== SETTERS ==============================
-    
+
+    # .text
+    describe '.text' do
+      before { subject.text('Page') }
+
+      it { expect(subject.page_number_text).to eq 'Page' }
+    end
+
     # .align
     describe '.align' do
       before { subject.align(:left) }
@@ -91,7 +100,7 @@ describe Caracal::Core::Models::PageNumberModel do
     # .option_keys
     describe '.option_keys' do
       let(:actual)   { subject.send(:option_keys).sort }
-      let(:expected) { [:align, :show].sort }
+      let(:expected) { [:text, :align, :show].sort }
       
       it { expect(actual).to eq expected }
     end

--- a/spec/lib/caracal/core/page_numbers_spec.rb
+++ b/spec/lib/caracal/core/page_numbers_spec.rb
@@ -17,6 +17,7 @@ describe Caracal::Core::PageSettings do
       
     # readers
     describe 'page number readers' do
+      it { expect(subject.page_number_text).to eq nil }
       it { expect(subject.page_number_show).to eq false }
       it { expect(subject.page_number_align).to eq :center }
     end
@@ -34,42 +35,50 @@ describe Caracal::Core::PageSettings do
     describe '.page_numbers' do
       describe 'when nothing given' do
         before { subject.page_numbers }
-        
+
+        it { expect(subject.page_number_text).to eq nil }
         it { expect(subject.page_number_show).to eq false }
         it { expect(subject.page_number_align).to eq :center }
       end
       describe 'when explicitly turned off' do
         before { subject.page_numbers false }
-        
+
+        it { expect(subject.page_number_text).to eq nil }
         it { expect(subject.page_number_show).to eq false }
         it { expect(subject.page_number_align).to eq :center }
       end
       describe 'when options given' do
-        before { subject.page_numbers true, align: :left }
-        
+        before { subject.page_numbers true, text: 'Custom Text', align: :left }
+
+        it { expect(subject.page_number_text).to eq 'Custom Text' }
         it { expect(subject.page_number_show).to eq true }
         it { expect(subject.page_number_align).to eq :left }
       end
       describe 'when block given' do
         before do
           subject.page_numbers true do
+            text 'More Text'
             align :left
           end
         end
-        
+
+        it { expect(subject.page_number_text).to eq 'More Text' }
         it { expect(subject.page_number_show).to eq true }
         it { expect(subject.page_number_align).to eq :left }
       end
       describe 'when fancy block given' do
         subject do
           Caracal::Document.new do |docx|
+            t = 'This is text'
             a = :left
             docx.page_numbers true do
+              text t
               align a
             end
           end
         end
-        
+
+        it { expect(subject.page_number_text).to eq 'This is text' }
         it { expect(subject.page_number_show).to eq true }
         it { expect(subject.page_number_align).to eq :left }
       end

--- a/spec/lib/caracal/core/page_numbers_spec.rb
+++ b/spec/lib/caracal/core/page_numbers_spec.rb
@@ -17,7 +17,7 @@ describe Caracal::Core::PageSettings do
       
     # readers
     describe 'page number readers' do
-      it { expect(subject.page_number_text).to eq nil }
+      it { expect(subject.page_number_label).to eq nil }
       it { expect(subject.page_number_show).to eq false }
       it { expect(subject.page_number_align).to eq :center }
     end
@@ -36,33 +36,33 @@ describe Caracal::Core::PageSettings do
       describe 'when nothing given' do
         before { subject.page_numbers }
 
-        it { expect(subject.page_number_text).to eq nil }
+        it { expect(subject.page_number_label).to eq nil }
         it { expect(subject.page_number_show).to eq false }
         it { expect(subject.page_number_align).to eq :center }
       end
       describe 'when explicitly turned off' do
         before { subject.page_numbers false }
 
-        it { expect(subject.page_number_text).to eq nil }
+        it { expect(subject.page_number_label).to eq nil }
         it { expect(subject.page_number_show).to eq false }
         it { expect(subject.page_number_align).to eq :center }
       end
       describe 'when options given' do
-        before { subject.page_numbers true, text: 'Custom Text', align: :left }
+        before { subject.page_numbers true, label: 'Custom Text', align: :left }
 
-        it { expect(subject.page_number_text).to eq 'Custom Text' }
+        it { expect(subject.page_number_label).to eq 'Custom Text' }
         it { expect(subject.page_number_show).to eq true }
         it { expect(subject.page_number_align).to eq :left }
       end
       describe 'when block given' do
         before do
           subject.page_numbers true do
-            text 'More Text'
+            label 'More Text'
             align :left
           end
         end
 
-        it { expect(subject.page_number_text).to eq 'More Text' }
+        it { expect(subject.page_number_label).to eq 'More Text' }
         it { expect(subject.page_number_show).to eq true }
         it { expect(subject.page_number_align).to eq :left }
       end
@@ -72,13 +72,13 @@ describe Caracal::Core::PageSettings do
             t = 'This is text'
             a = :left
             docx.page_numbers true do
-              text t
+              label t
               align a
             end
           end
         end
 
-        it { expect(subject.page_number_text).to eq 'This is text' }
+        it { expect(subject.page_number_label).to eq 'This is text' }
         it { expect(subject.page_number_show).to eq true }
         it { expect(subject.page_number_align).to eq :left }
       end


### PR DESCRIPTION
Thanks for this amazing gem, it is so incredibly useful.

Our use case needed text to be added to the left side of the page numbers, this pull request seems to do the trick. It could easily be modified to add text to the right side as well if needed.