### PR TITLE
README corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ dimensions and the orientation explicitly.
 docx.page_size do
   width       12240       # sets the page width. units in twips.
   height      15840       # sets the page height. units in twips.
-  orientation :landscape  # sets the printer orientation. accepts :portrait and :landscape.
+  orientation 'landscape' # sets the printer orientation. accepts 'portrait' and 'landscape'.
 end
 ```
 


### PR DESCRIPTION
Changed the landscape options from symbols to strings.
Symbols are not seen as correct values.