### PR TITLE
Fix: don't inject empty paragraph between tables

### DIFF
--- a/lib/caracal/core/models/table_model.rb
+++ b/lib/caracal/core/models/table_model.rb
@@ -36,14 +36,16 @@ module Caracal
         attr_reader :table_border_right       # returns border model
         attr_reader :table_border_horizontal  # returns border model
         attr_reader :table_border_vertical    # returns border model
+        attr_reader :table_leading_paragraph
         
         # initialization
         def initialize(options={}, &block)
-          @table_align          = DEFAULT_TABLE_ALIGN
-          @table_border_color   = DEFAULT_TABLE_BORDER_COLOR
-          @table_border_line    = DEFAULT_TABLE_BORDER_LINE
-          @table_border_size    = DEFAULT_TABLE_BORDER_SIZE
-          @table_border_spacing = DEFAULT_TABLE_BORDER_SPACING
+          @table_align             = DEFAULT_TABLE_ALIGN
+          @table_border_color      = DEFAULT_TABLE_BORDER_COLOR
+          @table_border_line       = DEFAULT_TABLE_BORDER_LINE
+          @table_border_size       = DEFAULT_TABLE_BORDER_SIZE
+          @table_border_spacing    = DEFAULT_TABLE_BORDER_SPACING
+          @table_leading_paragraph = true
           
           super options, &block
         end
@@ -117,6 +119,9 @@ module Caracal
           end
         end
         
+        def leading_paragraph(value)
+          @table_leading_paragraph = !!value
+        end
         
         #=============== SETTERS ==============================
         

--- a/lib/caracal/core/tables.rb
+++ b/lib/caracal/core/tables.rb
@@ -27,6 +27,9 @@ module Caracal
             end
             
             if model.valid?
+              if (previous = contents.last).is_a?(Caracal::Core::Models::TableModel)
+                previous.leading_paragraph(false)
+              end
               contents << model
             else
               raise Caracal::Errors::InvalidModelError, 'Table must be provided data for at least one cell.'

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -352,9 +352,11 @@ module Caracal
           end
         end
 
-        # don't know why this is needed, but it prevents a
-        # rendering error.
-        render_paragraph(xml, Caracal::Core::Models::ParagraphModel.new)
+        if model.table_leading_paragraph
+          # don't know why this is needed, but it prevents a
+          # rendering error.
+          render_paragraph(xml, Caracal::Core::Models::ParagraphModel.new)
+        end
       end
 
 


### PR DESCRIPTION
For some reason we must inject an empty paragraph right after a table to avoid rendering errors, but this isn't required when the table is immediately followed by another table.

If tables must be separated, one can still inject a paragraph manually between tables.