### PR TITLE
Add the possibility to set custom label size in the footer

### DIFF
--- a/lib/caracal/core/models/page_number_model.rb
+++ b/lib/caracal/core/models/page_number_model.rb
@@ -17,17 +17,20 @@ module Caracal
         # constants
         const_set(:DEFAULT_PAGE_NUMBER_ALIGN, :center)
         const_set(:DEFAULT_PAGE_NUMBER_SHOW,  false)
+        const_set(:DEFAULT_PAGE_NUMBER_LABEL_SIZE,  20)
 
         # accessors
         attr_reader :page_number_align
         attr_reader :page_number_label
         attr_reader :page_number_show
+        attr_reader :page_number_label_size
 
         # initialization
         def initialize(options={}, &block)
           @page_number_align = DEFAULT_PAGE_NUMBER_ALIGN
           @page_number_label = nil
           @page_number_show  = DEFAULT_PAGE_NUMBER_SHOW
+          @page_number_label_size = 20
 
           super options, &block
         end
@@ -49,6 +52,10 @@ module Caracal
 
         def show(value)
           @page_number_show = !!value
+        end
+
+        def size(value)
+          @page_number_label_size = value.to_i
         end
 
 

--- a/lib/caracal/core/page_numbers.rb
+++ b/lib/caracal/core/page_numbers.rb
@@ -23,6 +23,7 @@ module Caracal
           attr_reader :page_number_align
           attr_reader :page_number_label
           attr_reader :page_number_show
+          attr_reader :page_number_label_size
 
 
           #-------------------------------------------------------------
@@ -41,6 +42,7 @@ module Caracal
               @page_number_align = model.page_number_align
               @page_number_label = model.page_number_label
               @page_number_show  = model.page_number_show
+              @page_number_label_size = model.page_number_label_size
             else
               raise Caracal::Errors::InvalidModelError, 'page_numbers :align parameter must be :left, :center, or :right'
             end

--- a/lib/caracal/renderers/footer_renderer.rb
+++ b/lib/caracal/renderers/footer_renderer.rb
@@ -26,6 +26,7 @@ module Caracal
                 xml['w'].r run_options do
                   xml['w'].rPr do
                     xml['w'].rStyle({ 'w:val' => 'PageNumber' })
+                    xml['w'].sz({ 'w:val'  => document.page_number_label_size})
                   end
                   xml['w'].t({ 'xml:space' => 'preserve' }) do
                     xml.text "#{ document.page_number_label } "


### PR DESCRIPTION
A small commit to add the possibility of changing the text size in the footer. Defaults to 20.