### PR TITLE
Add vertical merge feature to table cells

### DIFF
--- a/lib/caracal/core/models/table_cell_model.rb
+++ b/lib/caracal/core/models/table_cell_model.rb
@@ -19,18 +19,21 @@ module Caracal
         const_set(:DEFAULT_CELL_BACKGROUND,       'ffffff')
         const_set(:DEFAULT_CELL_MARGINS,          Caracal::Core::Models::MarginModel.new({ top: 100, bottom: 100, left: 100, right: 100 }))
         const_set(:DEFAULT_CELL_VERTICAL_ALIGN,   :top)
+        const_set(:DEFAULT_CELL_VERTICAL_MERGE,   nil)
 
         # accessors
         attr_reader :cell_background
         attr_reader :cell_width
         attr_reader :cell_margins
         attr_reader :cell_vertical_align
+        attr_reader :cell_vertical_merge
 
         # initialization
         def initialize(options={}, &block)
           @cell_background      = DEFAULT_CELL_BACKGROUND
           @cell_margins         = DEFAULT_CELL_MARGINS
           @cell_vertical_align  = DEFAULT_CELL_VERTICAL_ALIGN
+          @cell_vertical_merge  = DEFAULT_CELL_VERTICAL_MERGE
 
           if content = options.delete(:content)
             p content, options.dup, &block
@@ -133,6 +136,12 @@ module Caracal
 
         # strings
         [:background].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set("@cell_#{ m }", value.to_s)
+          end
+        end
+
+        [:vertical_merge].each do |m|
           define_method "#{ m }" do |value|
             instance_variable_set("@cell_#{ m }", value.to_s)
           end

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -336,6 +336,9 @@ module Caracal
                   xml['w'].tcPr do
                     xml['w'].shd({ 'w:fill' => tc.cell_background })
                     xml['w'].vAlign({ 'w:val' => tc.cell_vertical_align })
+                    unless tc.cell_vertical_merge.nil?
+                      xml['w'].vMerge({ 'w:val' => tc.cell_vertical_merge })
+                    end
                     xml['w'].tcMar do
                       %w(top left bottom right).each do |d|
                         xml['w'].method_missing "#{ d }", { 'w:w' => tc.send("cell_margin_#{ d }").to_f, 'w:type' => 'dxa' }


### PR DESCRIPTION
John please consider this approach to implement vertical merge in table cells. 

Maybe its not too sophisticated, but it works. Here is how:

```
vmerge = nil
if condition_to_continue_merge_cell
     vmerge = 'continue'  #probably you want this to be more fancy
elsif condition_to_start_new_merge_cell
     vmerge = 'restart'  #probably you want this to be more fancy
end
cell = Caracal::Core::Models::TableCellModel.new do
     vertical_merge vmerge unless vmerge.nil?
     p 'Foo text'
end
```

I think is a good place to start.  What do you think?

More info [here](https://msdn.microsoft.com/en-us/library/documentformat.openxml.wordprocessing.verticalmerge(v=office.14).aspx), look for vMerge property