### PR TITLE
Add character style feature for text

### DIFF
--- a/lib/caracal/core/models/style_model.rb
+++ b/lib/caracal/core/models/style_model.rb
@@ -31,6 +31,7 @@ module Caracal
         # accessors
         attr_reader :style_default
         attr_reader :style_id
+        attr_reader :style_type
         attr_reader :style_name
         attr_reader :style_color
         attr_reader :style_font
@@ -52,6 +53,7 @@ module Caracal
         # initialization
         def initialize(options={}, &block)
           @style_default = false
+          @style_type    = 'paragraph'
           @style_base    = DEFAULT_STYLE_BASE
           @style_next    = DEFAULT_STYLE_NEXT
 
@@ -94,7 +96,7 @@ module Caracal
         end
 
         # strings
-        [:id, :name, :color, :font].each do |m|
+        [:type, :id, :name, :color, :font].each do |m|
           define_method "#{ m }" do |value|
             instance_variable_set("@style_#{ m }", value.to_s)
           end
@@ -129,7 +131,7 @@ module Caracal
         private
 
         def option_keys
-          [:bold, :italic, :underline, :caps, :top, :bottom, :size, :line, :id, :name, :color, :font, :align, :indent_left, :indent_right, :indent_first]
+          [:type, :bold, :italic, :underline, :caps, :top, :bottom, :size, :line, :id, :name, :color, :font, :align, :indent_left, :indent_right, :indent_first]
         end
 
       end

--- a/lib/caracal/core/models/text_model.rb
+++ b/lib/caracal/core/models/text_model.rb
@@ -15,6 +15,7 @@ module Caracal
         #-------------------------------------------------------------
 
         # accessors
+        attr_reader :text_style
         attr_reader :text_content
         attr_reader :text_font
         attr_reader :text_color
@@ -36,6 +37,7 @@ module Caracal
         # .run_attributes
         def run_attributes
           {
+            style:          text_style,
             font:           text_font,
             color:          text_color,
             size:           text_size,
@@ -65,7 +67,7 @@ module Caracal
         end
 
         # strings
-        [:bgcolor, :color, :content, :font].each do |m|
+        [:style, :bgcolor, :color, :content, :font].each do |m|
           define_method "#{ m }" do |value|
             instance_variable_set("@text_#{ m }", value.to_s)
           end
@@ -93,7 +95,7 @@ module Caracal
         private
 
         def option_keys
-          [:content, :font, :color, :size, :bold, :italic, :underline, :bgcolor, :vertical_align]
+          [:style, :content, :font, :color, :size, :bold, :italic, :underline, :bgcolor, :vertical_align]
         end
 
         def method_missing(method, *args, &block)

--- a/lib/caracal/renderers/styles_renderer.rb
+++ b/lib/caracal/renderers/styles_renderer.rb
@@ -62,10 +62,10 @@ module Caracal
             default_id = s.style_id
 
 
-            #============ PARAGRAPH STYLES ================================
+            #============ PARAGRAPH/CHARACTER STYLES ================================
 
             document.styles.reject { |s| s.style_id == default_id }.each do |s|
-              xml['w'].style({ 'w:styleId' => s.style_id, 'w:type' => 'paragraph' }) do
+              xml['w'].style({ 'w:styleId' => s.style_id, 'w:type' => s.style_type }) do
                 xml['w'].name({ 'w:val' => s.style_name })
                 xml['w'].basedOn({ 'w:val' => s.style_base })
                 xml['w'].next({ 'w:val' => s.style_next })


### PR DESCRIPTION
A small commit to add the possibility of changing styles for text node.

Your code:
```ruby
docx.style do
  id 'monospaced'
  name 'monospaced'
  type 'character'
  font 'Courier New'
end

docx.p do
  text 'Use '
  text 'bundle install', style: 'monospaced'
  text ' to install gems.'
end
```
Expected behavior:

![image](https://user-images.githubusercontent.com/6194939/34508714-bed1d418-f085-11e7-94a1-a362227e4a10.png)

See also:
http://officeopenxml.com/WPstyleCharStyles.php