### PR TITLE
Colspan and rowspan

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,17 @@ docx.table [['Header 1','Header 2'],['Cell 1', 'Cell 2']], border_size: 4 do
 end
 ```
 
+It is possible to merge cells vertically and horizontally using the `rowspan` and `colspan` options in `cell_style` method e.g.
+
+```ruby
+docx.table [['11', '1213', '14'], ['21', '22', '23', '24']] do
+  cell_style rows[0][0], rowspan: 2 
+  cell_style rows[0][1], colspan: 2 
+  cell_style rows[0][2], rowspan: 2 
+end
+```
+
+*Note: content of cells 21 and 24 will disappear*
 
 ### Table Cells
 

--- a/lib/caracal/core/models/table_cell_model.rb
+++ b/lib/caracal/core/models/table_cell_model.rb
@@ -25,6 +25,8 @@ module Caracal
         attr_reader :cell_width
         attr_reader :cell_margins
         attr_reader :cell_vertical_align
+        attr_reader :cell_rowspan
+        attr_reader :cell_colspan
 
         # initialization
         def initialize(options={}, &block)
@@ -118,7 +120,7 @@ module Caracal
         #=============== SETTERS ==============================
 
         # integers
-        [:width].each do |m|
+        [:width, :colspan, :rowspan].each do |m|
           define_method "#{ m }" do |value|
             instance_variable_set("@cell_#{ m }", value.to_i)
           end
@@ -145,7 +147,6 @@ module Caracal
           end
         end
 
-
         #=============== VALIDATION ===========================
 
         def valid?
@@ -159,7 +160,7 @@ module Caracal
         private
 
         def option_keys
-          [:background, :margins, :width, :vertical_align]
+          [:background, :margins, :width, :vertical_align, :rowspan, :colspan]
         end
 
       end

--- a/lib/caracal/core/models/table_model.rb
+++ b/lib/caracal/core/models/table_model.rb
@@ -95,7 +95,7 @@ module Caracal
         # end
         #
         def cell_style(models, options={})
-          [models].flatten.each do |m|
+          [models].flatten.compact.each do |m|
             m.apply_styles(options)
           end  
         end


### PR DESCRIPTION
Hello, I've been able to implement colspan and rowspan functionallity, please take a look.

Here is the example code 
```
docx.table([[11, 1213, 14], [21, 22, 23, 24]]) do
      cell_style rows[0][0], rowspan: 2
      cell_style rows[0][1], colspan: 2
      cell_style rows[0][2], rowspan: 2
end
```
used for generating the following file
 
[example.docx](https://github.com/trade-informatics/caracal/files/2031122/example.docx)