### PR TITLE
Added the ability to add to the header

### DIFF
--- a/lib/caracal/core/models/image_model.rb
+++ b/lib/caracal/core/models/image_model.rb
@@ -97,9 +97,8 @@ module Caracal
           define_method "#{ m }" do |value|
             instance_variable_set("@image_#{ m }", value.to_s.to_sym)
           end
-        end        
-        
-        
+        end
+
         #=============== VALIDATION ==============================
         
         def valid?

--- a/lib/caracal/core/models/relationship_model.rb
+++ b/lib/caracal/core/models/relationship_model.rb
@@ -17,6 +17,7 @@ module Caracal
         # constants
         TYPE_MAP = {
           font:       'http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable', 
+          header:     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header',
           footer:     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer',
           image:      'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
           link:       'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',

--- a/lib/caracal/core/namespaces.rb
+++ b/lib/caracal/core/namespaces.rb
@@ -68,7 +68,7 @@ module Caracal
           #============== REGISTRATION ========================
 
           def register_namespace(model)
-            unless ns = find_namespace(model.namespace_prefix)
+            unless (ns = find_namespace(model.namespace_prefix))
               namespaces << model
               ns = model
             end
@@ -76,7 +76,7 @@ module Caracal
           end
 
           def unregister_namespace(prefix)
-            if ns = find_namespace(prefix)
+            if (ns = find_namespace(prefix))
               namespaces.delete(ns)
             end
           end

--- a/lib/caracal/core/relationships.rb
+++ b/lib/caracal/core/relationships.rb
@@ -26,6 +26,7 @@ module Caracal
           def self.default_relationships
             [
               { target: 'fontTable.xml',  type: :font      },
+              { target: 'header1.xml',    type: :header    },
               { target: 'footer1.xml',    type: :footer    },
               { target: 'numbering.xml',  type: :numbering },
               { target: 'settings.xml',   type: :setting   },
@@ -69,7 +70,7 @@ module Caracal
           #============== REGISTRATION ========================
           
           def register_relationship(model)
-            unless r = find_relationship(model.relationship_target)
+            unless (r = find_relationship(model.relationship_target))
               relationships << model
               r = model
             end
@@ -77,7 +78,7 @@ module Caracal
           end
           
           def unregister_relationship(target)
-            if r = find_relationship(target)
+            if (r = find_relationship(target))
               relationships.delete(r)
             end
           end

--- a/lib/caracal/header.rb
+++ b/lib/caracal/header.rb
@@ -1,0 +1,75 @@
+require 'caracal/core/bookmarks'
+require 'caracal/core/custom_properties'
+require 'caracal/core/file_name'
+require 'caracal/core/fonts'
+require 'caracal/core/iframes'
+require 'caracal/core/ignorables'
+require 'caracal/core/images'
+require 'caracal/core/list_styles'
+require 'caracal/core/lists'
+require 'caracal/core/namespaces'
+require 'caracal/core/page_breaks'
+require 'caracal/core/page_numbers'
+require 'caracal/core/page_settings'
+require 'caracal/core/relationships'
+require 'caracal/core/rules'
+require 'caracal/core/styles'
+require 'caracal/core/tables'
+require 'caracal/core/text'
+
+require 'caracal/renderers/app_renderer'
+require 'caracal/renderers/content_types_renderer'
+require 'caracal/renderers/core_renderer'
+require 'caracal/renderers/custom_renderer'
+require 'caracal/renderers/document_renderer'
+require 'caracal/renderers/fonts_renderer'
+require 'caracal/renderers/header_renderer'
+require 'caracal/renderers/footer_renderer'
+require 'caracal/renderers/numbering_renderer'
+require 'caracal/renderers/package_relationships_renderer'
+require 'caracal/renderers/relationships_renderer'
+require 'caracal/renderers/header_relationship_renderer'
+require 'caracal/renderers/settings_renderer'
+require 'caracal/renderers/styles_renderer'
+
+
+module Caracal
+  class Header
+    include Caracal::Core::CustomProperties
+    include Caracal::Core::FileName
+    include Caracal::Core::Ignorables
+    include Caracal::Core::Namespaces
+    include Caracal::Core::Relationships
+
+    include Caracal::Core::Fonts
+    include Caracal::Core::PageSettings
+    include Caracal::Core::PageNumbers
+    include Caracal::Core::Styles
+    include Caracal::Core::ListStyles
+
+    include Caracal::Core::Bookmarks
+    include Caracal::Core::IFrames
+    include Caracal::Core::Images
+    include Caracal::Core::Lists
+    include Caracal::Core::PageBreaks
+    include Caracal::Core::Rules
+    include Caracal::Core::Tables
+    include Caracal::Core::Text
+
+    def initialize
+      page_size
+      page_margins top: 1440, bottom: 1440, left: 1440, right: 1440
+
+      [:font, :list_style, :namespace, :style].each do |method|
+        collection = self.class.send("default_#{ method }s")
+        collection.each do |item|
+          send(method, item)
+        end
+      end
+    end
+
+    def contents
+      @contents ||= []
+    end
+  end
+end

--- a/lib/caracal/renderers/content_types_renderer.rb
+++ b/lib/caracal/renderers/content_types_renderer.rb
@@ -27,6 +27,7 @@ module Caracal
             xml.send 'Override', { 'PartName' => '/docProps/core.xml',   'ContentType' => 'application/vnd.openxmlformats-package.core-properties+xml' }
             xml.send 'Override', { 'PartName' => '/docProps/custom.xml', 'ContentType' => 'application/vnd.openxmlformats-officedocument.custom-properties+xml' }
             xml.send 'Override', { 'PartName' => '/word/document.xml',   'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml' }
+            xml.send 'Override', { 'PartName' => '/word/header1.xml',    'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml' }
             xml.send 'Override', { 'PartName' => '/word/footer1.xml',    'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml' }
             xml.send 'Override', { 'PartName' => '/word/fontTable.xml',  'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml' }
             xml.send 'Override', { 'PartName' => '/word/numbering.xml',  'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml' }

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -32,7 +32,10 @@ module Caracal
 
               xml['w'].sectPr do
                 if document.page_number_show
-                  if rel = document.find_relationship('footer1.xml')
+                  if (rel = document.find_relationship('header1.xml'))
+                    xml['w'].headerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
+                  end
+                  if (rel = document.find_relationship('footer1.xml'))
                     xml['w'].footerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
                   end
                 end
@@ -125,13 +128,13 @@ module Caracal
             index = model.relationship_id           # relationship an id.
 
             r_node  = fragment.at_xpath("//a:blip[@r:embed='#{ id }']", { a: a_href, r: r_href })
-            if r_attr  = r_node.attributes['embed']
+            if (r_attr = r_node.attributes['embed'])
               r_attr.value = "rId#{ index }"
             end
 
             p_parent = r_node.parent.parent
             p_node   = p_parent.children[0].children[0]
-            if p_attr  = p_node.attributes['id']
+            if (p_attr = p_node.attributes['id'])
               p_attr.value = index.to_s
             end
           end
@@ -141,7 +144,7 @@ module Caracal
       end
 
       def render_image(xml, model)
-        unless ds = document.default_style
+        unless (ds = document.default_style)
           raise Caracal::Errors::NoDefaultStyleError 'Document must declare a default paragraph style.'
         end
 

--- a/lib/caracal/renderers/header_relationship_renderer.rb
+++ b/lib/caracal/renderers/header_relationship_renderer.rb
@@ -1,0 +1,44 @@
+require 'nokogiri'
+
+require 'caracal/renderers/xml_renderer'
+
+module Caracal
+  module Renderers
+    class HeaderRelationshipRenderer < XmlRenderer
+      #-------------------------------------------------------------
+      # Public Methods
+      #-------------------------------------------------------------
+
+      # This method produces the xml required for the `word/settings.xml`
+      # sub-document.
+      #
+      def to_xml
+        builder = ::Nokogiri::XML::Builder.with(declaration_xml) do |xml|
+          xml.send 'Relationships', root_options do
+            document.relationships.each do |rel|
+              xml.send 'Relationship', rel_options(rel)
+            end
+          end
+        end
+        builder.to_xml(save_options)
+      end
+
+      #-------------------------------------------------------------
+      # Private Methods
+      #-------------------------------------------------------------
+      private
+
+      def rel_options(rel)
+        opts = { 'Target' => rel.formatted_target, 'Type' => rel.formatted_type, 'Id' => rel.formatted_id}
+        opts['TargetMode'] = 'External' if rel.target_mode?
+        opts
+      end
+
+      def root_options
+        {
+            'xmlns' => 'http://schemas.openxmlformats.org/package/2006/relationships'
+        }
+      end
+    end
+  end
+end

--- a/lib/caracal/renderers/header_renderer.rb
+++ b/lib/caracal/renderers/header_renderer.rb
@@ -1,0 +1,62 @@
+require 'nokogiri'
+
+require 'caracal/renderers/document_renderer'
+
+
+module Caracal
+  module Renderers
+    class HeaderRenderer < DocumentRenderer
+
+      #-------------------------------------------------------------
+      # Public Methods
+      #-------------------------------------------------------------
+
+      # This method produces the xml required for the `word/header1.xml`
+      # sub-document.
+      #
+      def to_xml
+        builder = ::Nokogiri::XML::Builder.with(declaration_xml) do |xml|
+          xml['w'].hdr header_root_options do
+            document.contents.each do |model|
+              method = render_method_for_model(model)
+              send(method, xml, model)
+            end
+          end
+        end
+        builder.to_xml(save_options)
+      end
+
+      def render_pagebreak(xml, model); end
+
+      def render_iframe(xml, model); end
+
+      #-------------------------------------------------------------
+      # Private Methods
+      #-------------------------------------------------------------
+      private
+
+      def header_root_options
+        {
+          'xmlns:mc'  => 'http://schemas.openxmlformats.org/markup-compatibility/2006',
+          'xmlns:o'   => 'urn:schemas-microsoft-com:office:office',
+          'xmlns:r'   => 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+          'xmlns:m'   => 'http://schemas.openxmlformats.org/officeDocument/2006/math',
+          'xmlns:v'   => 'urn:schemas-microsoft-com:vml',
+          'xmlns:wp'  => 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing',
+          'xmlns:w10' => 'urn:schemas-microsoft-com:office:word',
+          'xmlns:w'   => 'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+          'xmlns:wne' => 'http://schemas.microsoft.com/office/word/2006/wordml',
+          'xmlns:sl'  => 'http://schemas.openxmlformats.org/schemaLibrary/2006/main',
+          'xmlns:a'   => 'http://schemas.openxmlformats.org/drawingml/2006/main',
+          'xmlns:pic' => 'http://schemas.openxmlformats.org/drawingml/2006/picture',
+          'xmlns:c'   => 'http://schemas.openxmlformats.org/drawingml/2006/chart',
+          'xmlns:lc'  => 'http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas',
+          'xmlns:dgm' => 'http://schemas.openxmlformats.org/drawingml/2006/diagram'
+        }
+      end
+
+    end
+  end
+end
+
+

--- a/lib/caracal/renderers/xml_renderer.rb
+++ b/lib/caracal/renderers/xml_renderer.rb
@@ -32,7 +32,7 @@ module Caracal
       # This method instantiates a new verison of this renderer.
       #
       def initialize(doc)
-        unless doc.is_a?(Caracal::Document)
+        unless doc.is_a?(Caracal::Document) or doc.is_a?(Caracal::Header)
           raise NoDocumentError, 'renderers must receive a reference to a valid Caracal document object.'
         end
 


### PR DESCRIPTION
Added the ability to add to the header all the same as in the body of the document except for pagebreak and iframe
Calling from code same as simple other commands (except line break and frames), but header command have to be add :

- docx.header.img ......
- docx.header.hr
- docx.header.h1 .....

Example:

```
Caracal::Document.render(filename) do |docx|
  docx.header.h1 'Page 1 Header'
  docx.header.img "http://web.dev.cvtako.com/talentako-logo-1.png" do
    width  60
    height 60
    align :right
  end

  docx.header.p "skdanflksamlkdfmlaksd"

  docx.header.table [['11', '1213', '14'], ['21', '22', '23', '24']] do
    cell_style rows[0][0], rowspan: 2
    cell_style rows[0][1], colspan: 2
    cell_style rows[0][2], rowspan: 2
  end

  docx.header.p do
    text 'Here is a sentence with a '
    link 'link', 'https://www.google.com'
    text ' to something awesome', font: 'Courier New', color: '555555', size: 32, bold: true, italic: true, underline: true, bgcolor: 'cccccc'
    text '.'
    br
    text 'This text follows a line break and uses a character style instead of overrides.', style: 'MyCharStyle'
    page
  end

  docx.header.ol do
    li 'First item'
    li do
      text 'Second item with a '
      link 'link', "http://web.dev.cvtako.com/talentako-logo-1.png"
      text '.'
      br
      text 'This sentence follows a line break.'
    end
  end

  docx.header.hr
end
```