### PR TITLE
Fix rowspan handling for table cells

### DIFF
--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -351,7 +351,8 @@ module Caracal
           rowspan_hash = {}
           model.rows.each do |row|
             xml['w'].tr do
-              row.each_with_index do |tc, tc_index|
+              tc_index = 0
+              row.each do |tc|
                 xml['w'].tc do
                   xml['w'].tcPr do
                     xml['w'].shd({ 'w:fill' => tc.cell_background })
@@ -380,24 +381,11 @@ module Caracal
                     send(method, xml, m)
                   end
                 end
+
+                # adjust tc_index for next cell taking into account current cell's colspan
+                tc_index += (tc.cell_colspan && tc.cell_colspan > 0) ? tc.cell_colspan : 1
               end
             end
-
-            # we need to adjust rowspan indexes as they depend on previous row colspans
-            adjusted_rowspan_hash = {}
-            rowspan_hash.each do |rowspan_cell_index, rowspan_value|
-              adjusted_rowspan_cell_index = rowspan_cell_index
-              row.each_with_index do |tc, tc_index|
-                if tc.cell_colspan && tc.cell_colspan >= 1
-                  if tc_index < rowspan_cell_index
-                    adjusted_rowspan_cell_index += tc.cell_colspan - 1
-                  end
-                end
-              end
-              adjusted_rowspan_hash[adjusted_rowspan_cell_index] = rowspan_value
-            end
-
-            rowspan_hash = adjusted_rowspan_hash
           end
         end
       end


### PR DESCRIPTION
This fixes rowspan handling for table cells

```ruby
data = [
  ['11,12; 21,22', '13', '14,15; 24,25'],
  ['',             '23', ''            ],
  ['31',  '32',    '33', '34',  '35'   ],
]

docx.table data do
  border_color   '666666'
  border_line    :single
  border_size    1

  cell_style rows[0][0], colspan: 2, rowspan: 2
  cell_style rows[0][2], colspan: 2, rowspan: 2

  cell_style rows[1][0], colspan: 2
  cell_style rows[1][2], colspan: 2
end
```

<details>
<summary>Result before patch</summary>

<img width="672" alt="rowspan-before" src="https://user-images.githubusercontent.com/557122/54999141-4a531580-4fd8-11e9-847a-c315423e9e1e.png">

</details>

<details>
<summary>Result after the patch applied</summary>
<img width="671" alt="rowspan-after" src="https://user-images.githubusercontent.com/557122/54999197-648cf380-4fd8-11e9-9c8b-90ea85b8ceac.png">
</details>

