### PR TITLE
Allow Rubyzip 2.0

### DIFF
--- a/caracal.gemspec
+++ b/caracal.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'nokogiri', '~> 1.6'
-  spec.add_dependency 'rubyzip',  '~> 1.1'
+  spec.add_dependency 'rubyzip',  ['>= 1.1.0', '< 3.0']
   spec.add_dependency 'tilt',     '>= 1.4'
 
   spec.add_development_dependency 'bundler',  '~> 1.3'


### PR DESCRIPTION
Rubyzip 2.0's two breaking changes are a new default for validation that
patches a potential security hole and dropping support for EOLed Rubies.

This change relaxes the dependency version range for Rubyzip so that
Caracal can work with Rubyzip 2.x.

https://github.com/rubyzip/rubyzip/blob/master/Changelog.md#200-2019-09-25

Close #143